### PR TITLE
Fix to add support for PyJWT>=2.0.0a1 and keep support for PyJWT<=1.7.1

### DIFF
--- a/src/jwt_auth.py
+++ b/src/jwt_auth.py
@@ -34,4 +34,8 @@ def make_jwt_payload(api_key: str, token_exp_delta: int) -> dict:
 
 def generate_jwt_token(payload: dict, api_secret: str) -> str:
     encoded = jwt.encode(payload, api_secret, algorithm='HS256')
-    return encoded.decode()
+    if isinstance(encoded, bytes):
+        # For PyJWT <= 1.7.1
+        return encoded.decode()
+    # For PyJWT >= 2.0.0a1
+    return encoded


### PR DESCRIPTION
Error msg:
```Traceback (most recent call last):
  File "src/main.py", line 45, in <module>
    86400
  File "/opt/app/src/zoom.py", line 27, in __init__
    self._setup()
  File "/opt/app/src/zoom.py", line 33, in _setup
    self.token_exp_delta
  File "/opt/app/src/jwt_auth.py", line 22, in generate_access_token
    return generate_jwt_token(jwt_payload, api_secret)
  File "/opt/app/src/jwt_auth.py", line 37, in generate_jwt_token
    return encoded.decode()
AttributeError: 'str' object has no attribute 'decode'
```

Some other project had the same error: https://github.com/SimpleJWT/django-rest-framework-simplejwt/pull/329/files